### PR TITLE
Fix long parse times from broken italics rule.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,6 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
     testCompile 'junit:junit:4.12'
     compile project(':simpleast-core')
 }

--- a/app/src/main/java/com/agarron/simpleast/MainActivity.java
+++ b/app/src/main/java/com/agarron/simpleast/MainActivity.java
@@ -6,18 +6,16 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.TextView;
 
-import com.agarron.simpleast_core.builder.Parser;
-import com.agarron.simpleast_core.node.Node;
-import com.agarron.simpleast_core.simple.SimpleMarkdownRules;
 import com.agarron.simpleast_core.simple.SimpleRenderer;
 
-import java.util.List;
+import java.io.InputStream;
+import java.util.Scanner;
 
 public class MainActivity extends AppCompatActivity {
 
     private static final int NUM_UNDERSCORES = 4000;
 
-    private TextView resultText;
+    private TextView resultTextView;
     private EditText input;
 
     @Override
@@ -25,7 +23,7 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        resultText = (TextView) findViewById(R.id.result_text);
+        resultTextView = (TextView) findViewById(R.id.result_text);
         input = (EditText) findViewById(R.id.input);
 
         input.setText("**bold _and italics_ and more bold**");
@@ -33,16 +31,15 @@ public class MainActivity extends AppCompatActivity {
         findViewById(R.id.crash_btn).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                SimpleRenderer.renderBasicMarkdown(resultText, createTestText());
-                final List<Node> ast = new Parser().addRules(SimpleMarkdownRules.getSimpleMarkdownRules()).parse(createTestText());
-                resultText.setText(SimpleRenderer.render(ast));
+                final String testText = loadTestText();
+                SimpleRenderer.renderBasicMarkdown(resultTextView, testText);
             }
         });
 
         findViewById(R.id.test_btn).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                SimpleRenderer.renderBasicMarkdown(resultText, input.getText());
+                SimpleRenderer.renderBasicMarkdown(resultTextView, input.getText());
             }
         });
     }
@@ -60,5 +57,15 @@ public class MainActivity extends AppCompatActivity {
         }
 
         return builder.toString();
+    }
+
+    private String loadTestText() {
+        final InputStream inputStream = getResources().openRawResource(R.raw.test_text);
+        return convertStreamToString(inputStream);
+    }
+
+    static String convertStreamToString(final InputStream inputStream) {
+        final Scanner s = new Scanner(inputStream).useDelimiter("\\A");
+        return s.hasNext() ? s.next() : "";
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -30,7 +30,7 @@
 
     <Button
         android:id="@+id/crash_btn"
-        android:text="Parse"
+        android:text="Parse Test Text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"/>
 

--- a/app/src/main/res/raw/test_text.txt
+++ b/app/src/main/res/raw/test_text.txt
@@ -1,0 +1,10 @@
+  File "/usr/local/lib/python3.5/dist-packages/youtube_dl/YoutubeDL.py", line 2000, in urlopen
+    req = sanitized_Request(req)
+  File "/usr/local/lib/python3.5/dist-packages/youtube_dl/utils.py", line 518, in sanitized_Request
+    return compat_urllib_request.Request(sanitize_url(url), *args, **kwargs)
+  File "/usr/lib/python3.5/urllib/request.py", line 269, in init
+    self.full_url = url
+  File "/usr/lib/python3.5/urllib/request.py", line 295, in full_url
+    self._parse()
+  File "/usr/lib/python3.5/urllib/request.py", line 324, in _parse
+    raise ValueError("unknown url type: %r" % self.full_url)

--- a/app/src/main/res/raw/test_text.txt
+++ b/app/src/main/res/raw/test_text.txt
@@ -1,3 +1,14 @@
+[0;31mERROR:[0m Signature extraction failed: Traceback (most recent call last):
+  File "/usr/local/lib/python3.5/dist-packages/youtube_dl/extractor/youtube.py", line 1011, in _decrypt_signature
+    video_id, player_url, s
+  File "/usr/local/lib/python3.5/dist-packages/youtube_dl/extractor/youtube.py", line 925, in _extract_signature_function
+    errnote='Download of %s failed' % player_url)
+  File "/usr/local/lib/python3.5/dist-packages/youtube_dl/extractor/common.py", line 519, in _download_webpage
+    res = self._download_webpage_handle(url_or_request, video_id, note, errnote, fatal, encoding=encoding, data=data, headers=headers, query=query)
+  File "/usr/local/lib/python3.5/dist-packages/youtube_dl/extractor/common.py", line 426, in _download_webpage_handle
+    urlh = self._request_webpage(url_or_request, video_id, note, errnote, fatal, data=data, headers=headers, query=query)
+  File "/usr/local/lib/python3.5/dist-packages/youtube_dl/extractor/common.py", line 406, in _request_webpage
+    return self._downloader.urlopen(url_or_request)
   File "/usr/local/lib/python3.5/dist-packages/youtube_dl/YoutubeDL.py", line 2000, in urlopen
     req = sanitized_Request(req)
   File "/usr/local/lib/python3.5/dist-packages/youtube_dl/utils.py", line 518, in sanitized_Request
@@ -8,3 +19,5 @@
     self._parse()
   File "/usr/lib/python3.5/urllib/request.py", line 324, in _parse
     raise ValueError("unknown url type: %r" % self.full_url)
+ValueError: unknown url type: '/yts/jsbin/player-en_US-vflkk7pUE/base.js'
+ (caused by ValueError("unknown url type: '/yts/jsbin/player-en_US-vflkk7pUE/base.js'",))

--- a/simpleast-core/src/main/java/com/agarron/simpleast_core/builder/Parser.java
+++ b/simpleast-core/src/main/java/com/agarron/simpleast_core/builder/Parser.java
@@ -38,28 +38,19 @@ public class Parser {
     }
 
     public List<Node> parse(final @Nullable CharSequence source) {
-        final long startMillis = System.currentTimeMillis();
-        long iterations = 0;
         final Stack<SubtreeSpec> stack = new Stack<>();
         final Root root = new Root();
 
-        if (!TextUtils.isEmpty(source)) {
+        if (!isTextEmpty(source)) {
             stack.add(new SubtreeSpec(root, 0, source.length()));
         }
 
         while (!stack.isEmpty()) {
-
-            iterations++;
-            final long iterationStartMillis = System.currentTimeMillis();
             final SubtreeSpec builder = stack.pop();
 
             if (builder.startIndex >= builder.endIndex) {
-                Log.e("findme", "breaking");
                 break;
             }
-
-            Log.d("findme", "iteration with startIndex: " + builder.startIndex + ", end index: " + builder.endIndex + " at depth: " + builder.depth);
-            Log.d("findme", "iteration with stack size: " + stack.size());
 
             final CharSequence inspectionSource = source.subSequence(builder.startIndex, builder.endIndex);
             final int offset = builder.startIndex;
@@ -98,17 +89,13 @@ public class Parser {
             if (!foundRule) {
                 throw new RuntimeException("failed to find rule to match source: \"" + inspectionSource + "\"");
             }
-
-            final long iterationEndMillis = System.currentTimeMillis();
-            if ((iterationEndMillis - iterationStartMillis) > 10L) {
-                Log.e("findme", "long iteration: " + inspectionSource + "\n took " + (iterationEndMillis - iterationStartMillis) + " ms");
-            }
         }
 
-        final long endMillis = System.currentTimeMillis();
-        Log.d("findme", "parse took: " + (endMillis - startMillis) + " ms and " + iterations + " iterations");
-
         return root.getChildren();
+    }
+
+    private static boolean isTextEmpty(final CharSequence text) {
+        return text == null || text.length() == 0;
     }
 
     /**
@@ -126,7 +113,6 @@ public class Parser {
         private final boolean isTerminal;
         private int startIndex;
         private int endIndex;
-        private int depth;
 
         public static SubtreeSpec createNonterminal(Parent node, int startIndex, int endIndex) {
             return new SubtreeSpec(node, startIndex, endIndex);
@@ -141,7 +127,6 @@ public class Parser {
             this.isTerminal = false;
             this.startIndex = startIndex;
             this.endIndex = endIndex;
-            this.depth = depth;
         }
 
         private SubtreeSpec(Node root) {

--- a/simpleast-core/src/main/java/com/agarron/simpleast_core/builder/Parser.java
+++ b/simpleast-core/src/main/java/com/agarron/simpleast_core/builder/Parser.java
@@ -1,8 +1,6 @@
 package com.agarron.simpleast_core.builder;
 
 import android.support.annotation.Nullable;
-import android.text.TextUtils;
-import android.util.Log;
 
 import com.agarron.simpleast_core.node.Node;
 import com.agarron.simpleast_core.node.Parent;

--- a/simpleast-core/src/main/java/com/agarron/simpleast_core/simple/SimpleMarkdownRules.java
+++ b/simpleast-core/src/main/java/com/agarron/simpleast_core/simple/SimpleMarkdownRules.java
@@ -34,7 +34,7 @@ public class SimpleMarkdownRules {
         // italics
         //  - whitespace
         //  - non-whitespace, non-* characters
-        "(?:\\*\\*|\\s+|[^\\s\\*])*?" +
+        "(?:\\*\\*|\\s+(?:[^\\*\\s]|\\*\\*)|[^\\s\\*])+?" +
         // followed by a non-space, non-* then *
         "[^\\s\\*])\\*(?!\\*)"
     );


### PR DESCRIPTION
Somehow when porting simple-markdown.js, a line in the italics rule that should have been:

```
"(?:\\*\\*|\\s+(?:[^\\*\\s]|\\*\\*)|[^\\s\\*])+?" +
```

was incorrectly ported as:

```
"(?:\\*\\*|\\s+|[^\\s\\*])*?" +
```

Without the missing part of that regex, the italics rule parser would not fail as early as it should have, resulting in long parse times on certain inputs, including [this one.](https://github.com/angarron/SimpleAST/blob/debd04629e5505ee2c93cebaddf5515020020427/app/src/main/res/raw/test_text.txt)

This PR fixes those parse times by adding the missing part of the regex.

### Also...

This PR updates the test app to point to that new test input and replaces a call to `TextUtils.isEmpty()` in `Parser` so the unit tests don't fail.