### PR TITLE
Cache matcher in rules for perf boost

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion '26.0.2'
     defaultConfig {
         applicationId "com.agarron.simpleast"
         minSdkVersion 16

--- a/app/src/main/java/com/agarron/simpleast/MainActivity.java
+++ b/app/src/main/java/com/agarron/simpleast/MainActivity.java
@@ -37,7 +37,7 @@ public class MainActivity extends AppCompatActivity {
         findViewById(R.id.benchmark_btn).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                final double times = 10.0;
+                final double times = 50.0;
                 long totalDuration = 0L;
                 for (int i = 0; i < times; i++) {
                     final long start = System.currentTimeMillis();

--- a/app/src/main/java/com/agarron/simpleast/MainActivity.java
+++ b/app/src/main/java/com/agarron/simpleast/MainActivity.java
@@ -34,7 +34,7 @@ public class MainActivity extends AppCompatActivity {
 
         input.setText("*t*");
 
-        findViewById(R.id.crash_btn).setOnClickListener(new View.OnClickListener() {
+        findViewById(R.id.benchmark_btn).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 final double times = 10.0;

--- a/app/src/main/java/com/agarron/simpleast/MainActivity.java
+++ b/app/src/main/java/com/agarron/simpleast/MainActivity.java
@@ -3,6 +3,7 @@ package com.agarron.simpleast;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.text.style.CharacterStyle;
+import android.util.Log;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -36,12 +37,18 @@ public class MainActivity extends AppCompatActivity {
         findViewById(R.id.crash_btn).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                final List<Parser.Rule<Node>> rules = getRules();
-                final List<Node> ast = new Parser<>()
-                    .addRules(rules)
-                    .parse(createTestText());
-
-                resultText.setText(SimpleRenderer.render(ast));
+                final double times = 10.0;
+                final String text = createTestText();
+                long totalDuration = 0L;
+                for (int i = 0; i < times; i++) {
+                    final long start = System.currentTimeMillis();
+                    testParse(50);
+                    final long end = System.currentTimeMillis();
+                    final long duration = end - start;
+                    totalDuration += duration;
+                    Log.d("findme", "duration of parse: " + duration + " ms");
+                }
+                Log.d("findme", "average parse time: " + totalDuration / times + " ms");
             }
         });
 
@@ -103,5 +110,13 @@ public class MainActivity extends AppCompatActivity {
             "    raise ValueError(\"unknown url type: %r\" % self.full_url)\n" +
             "ValueError: unknown url type: '/yts/jsbin/player-en_US-vflkk7pUE/base.js'\n" +
             " (caused by ValueError(\"unknown url type: '/yts/jsbin/player-en_US-vflkk7pUE/base.js'\",))";
+    }
+
+    private void testParse(final int times) {
+        final String text = createTestText();
+
+        for (int i = 0; i < times; i++) {
+            SimpleRenderer.renderBasicMarkdown(resultText, text);
+        }
     }
 }

--- a/app/src/main/java/com/agarron/simpleast/MainActivity.java
+++ b/app/src/main/java/com/agarron/simpleast/MainActivity.java
@@ -38,7 +38,6 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 final double times = 10.0;
-                final String text = createTestText();
                 long totalDuration = 0L;
                 for (int i = 0; i < times; i++) {
                     final long start = System.currentTimeMillis();
@@ -46,9 +45,9 @@ public class MainActivity extends AppCompatActivity {
                     final long end = System.currentTimeMillis();
                     final long duration = end - start;
                     totalDuration += duration;
-                    Log.d("findme", "duration of parse: " + duration + " ms");
+                    Log.d("timer", "duration of parse: " + duration + " ms");
                 }
-                Log.d("findme", "average parse time: " + totalDuration / times + " ms");
+                Log.d("timer", "average parse time: " + totalDuration / times + " ms");
             }
         });
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -29,8 +29,8 @@
         android:layout_height="wrap_content"/>
 
     <Button
-        android:id="@+id/crash_btn"
-        android:text="Parse Test Text"
+        android:id="@+id/benchmark_btn"
+        android:text="Benchmark Test Text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"/>
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 20 12:44:22 PST 2017
+#Mon Dec 18 14:24:16 PST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/simpleast-core/build.gradle
+++ b/simpleast-core/build.gradle
@@ -26,7 +26,6 @@ ext {
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 16

--- a/simpleast-core/src/main/java/com/agarron/simpleast_core/builder/Parser.java
+++ b/simpleast-core/src/main/java/com/agarron/simpleast_core/builder/Parser.java
@@ -38,6 +38,18 @@ public class Parser<T extends Node> {
     public List<T> parse(final @Nullable CharSequence source) {
         return parse(source, false);
     }
+//
+//    private Matcher getOrCreateMatcher(final Rule rule, final CharSequence text) {
+//      if (ruleMatchers.containsKey(rule)) {
+//          final Matcher cachedMatcher = ruleMatchers.get(rule);
+//          cachedMatcher.reset(text);
+//          return cachedMatcher;
+//      } else {
+//          final Matcher matcher = rule.pattern.matcher(text);
+//          ruleMatchers.put(rule, matcher);
+//          return matcher;
+//      }
+//    }
 
     public List<T> parse(final @Nullable CharSequence source, boolean isNested) {
         final Stack<SubtreeSpec> stack = new Stack<>();
@@ -63,7 +75,8 @@ public class Parser<T extends Node> {
                     continue;
                 }
 
-                final Matcher matcher = rule.pattern.matcher(inspectionSource);
+                final Matcher matcher = rule.matcher;
+                matcher.reset(inspectionSource);
 
                 if (matcher.find()) {
                     foundRule = true;
@@ -148,11 +161,11 @@ public class Parser<T extends Node> {
 
     public static abstract class Rule<T extends Node> {
 
-        private final Pattern pattern;
+        private final Matcher matcher;
         private final boolean applyOnNestedParse;
 
         public Rule(final Pattern pattern, final boolean applyOnNestedParse) {
-            this.pattern = pattern;
+            this.matcher = pattern.matcher("");
             this.applyOnNestedParse = applyOnNestedParse;
         }
 

--- a/simpleast-core/src/main/java/com/agarron/simpleast_core/builder/Parser.java
+++ b/simpleast-core/src/main/java/com/agarron/simpleast_core/builder/Parser.java
@@ -38,18 +38,6 @@ public class Parser<T extends Node> {
     public List<T> parse(final @Nullable CharSequence source) {
         return parse(source, false);
     }
-//
-//    private Matcher getOrCreateMatcher(final Rule rule, final CharSequence text) {
-//      if (ruleMatchers.containsKey(rule)) {
-//          final Matcher cachedMatcher = ruleMatchers.get(rule);
-//          cachedMatcher.reset(text);
-//          return cachedMatcher;
-//      } else {
-//          final Matcher matcher = rule.pattern.matcher(text);
-//          ruleMatchers.put(rule, matcher);
-//          return matcher;
-//      }
-//    }
 
     public List<T> parse(final @Nullable CharSequence source, boolean isNested) {
         final Stack<SubtreeSpec> stack = new Stack<>();
@@ -75,8 +63,7 @@ public class Parser<T extends Node> {
                     continue;
                 }
 
-                final Matcher matcher = rule.matcher;
-                matcher.reset(inspectionSource);
+                final Matcher matcher = rule.matcher.reset(inspectionSource);
 
                 if (matcher.find()) {
                     foundRule = true;


### PR DESCRIPTION
Makes parser ~1.5x faster.

The benchmark in this commit measures how long it takes to parse the test message in `MainActivity` 50 times. That trial (50 parses) is repeated N times to gain an average time to parse.

The baseline averaged 496.22 ms, after this PR we average 329.74 ms, which is just over a 1.5x speedup. Using messages from discord testers bug report channels we experience a 1.6x or 1.7x speedup.